### PR TITLE
BUGFIX: Fixed tracker opening script tag closing early

### DIFF
--- a/code/PardotTracker.php
+++ b/code/PardotTracker.php
@@ -30,7 +30,7 @@ class PardotTracker extends SiteTreeExtension
             $tracking_code_template = str_replace('%%CAMPAIGN_ID%%', $campaign+1000, $tracking_code_template);
             $campaign = $campaign + 1000;
             $html =<<<HTML
-<script> type="text/javascript">
+<script type="text/javascript">
 piCId = '{$campaign}';
 {$tracking_code_template}
 </script>


### PR DESCRIPTION
The tracker opening script tag is closing prematurely causing the tracker script to break and generate invalid html. This pull request removes the premature closing of the tracker's opening script tag.