### PR TITLE
Update the API version default to 4

### DIFF
--- a/thirdparty/Pardot/code/pardot-api-class.php
+++ b/thirdparty/Pardot/code/pardot-api-class.php
@@ -32,7 +32,7 @@ class Pardot_API {
 	 *
 	 * @since 1.0.0
 	 */
-	const VERSION = '3';
+	const VERSION = '4';
 
 	/**
 	 * @var string Defacto constant defining the URL path template for the API.


### PR DESCRIPTION
Many of the operations no longer seem to work with new Pardot accounts under the API v3