### PR TITLE
Switch to v4 of the API.

### DIFF
--- a/thirdparty/Pardot/code/pardot-api-class.php
+++ b/thirdparty/Pardot/code/pardot-api-class.php
@@ -32,7 +32,7 @@ class Pardot_API {
 	 *
 	 * @since 1.0.0
 	 */
-	const VERSION = '3';
+	const VERSION = '4';
 
 	/**
 	 * @var string Defacto constant defining the URL path template for the API.


### PR DESCRIPTION
The API appears to operate the same as v3, but some Pardot accounts will
not work with v3 of the API. I’ve tested the tracking code and form
insertion behaviour with this change and everything still works.